### PR TITLE
MULE-12609: Every exported Mule package must contain api

### DIFF
--- a/src/main/java/org/mule/extension/ftp/internal/sftp/connection/SftpClient.java
+++ b/src/main/java/org/mule/extension/ftp/internal/sftp/connection/SftpClient.java
@@ -11,7 +11,7 @@ import static java.lang.String.format;
 import static org.apache.commons.collections.CollectionUtils.isEmpty;
 import static org.mule.runtime.api.i18n.I18nMessageFactory.createStaticMessage;
 import static org.mule.runtime.core.api.util.StringUtils.isEmpty;
-import static org.mule.runtime.core.util.collection.Collectors.toImmutableList;
+import static org.mule.runtime.core.api.util.collection.Collectors.toImmutableList;
 import org.mule.extension.file.common.api.FileWriteMode;
 import org.mule.extension.file.common.api.exceptions.FileError;
 import org.mule.extension.ftp.api.FTPConnectionException;


### PR DESCRIPTION
_ Moving classes to api/internal packages
_ Removing unused code