### PR TITLE
MULE-13545: Cleanup core API

### DIFF
--- a/src/main/java/org/mule/extension/ftp/internal/sftp/connection/SftpClient.java
+++ b/src/main/java/org/mule/extension/ftp/internal/sftp/connection/SftpClient.java
@@ -13,7 +13,7 @@ import static org.mule.extension.ftp.internal.ftp.FtpUtils.normalizePath;
 import static org.mule.extension.ftp.internal.ftp.FtpUtils.resolvePath;
 import static org.mule.runtime.api.i18n.I18nMessageFactory.createStaticMessage;
 import static org.mule.runtime.core.api.util.StringUtils.isEmpty;
-import static org.mule.runtime.core.api.util.collection.Collectors.toImmutableList;
+import static org.mule.runtime.api.util.collection.Collectors.toImmutableList;
 import org.mule.extension.file.common.api.FileWriteMode;
 import org.mule.extension.file.common.api.exceptions.FileError;
 import org.mule.extension.ftp.api.FTPConnectionException;


### PR DESCRIPTION
_ Moving classes out of core's api package
_ When possible, classes where moved to internal
_ Moved to privileged when classes where required on compatibility
_ Moved to other module's API when needed on tests or it made sense
_ Deleted if not needed anymore
_ Some tests were ignored as they use an internal class and need refactoring