### PR TITLE
FTPC-57

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,7 @@
         <munit.output.directory>${basedir}/target/test-mule/munit</munit.output.directory>
         <munit.extensions.maven.plugin.version>1.0.0</munit.extensions.maven.plugin.version>
         <munit.version>2.2.4</munit.version>
+        <mtf.tools.version>1.0.0</mtf.tools.version>
         <mavenResources.version>3.0.2</mavenResources.version>
 
         <formatterConfigPath>formatter.xml</formatterConfigPath>
@@ -166,6 +167,12 @@
                         <groupId>com.mulesoft.munit</groupId>
                         <artifactId>munit-tools</artifactId>
                         <version>${munit.version}</version>
+                        <classifier>mule-plugin</classifier>
+                    </dependency>
+                    <dependency>
+                        <groupId>com.mulesoft.munit</groupId>
+                        <artifactId>mtf-tools</artifactId>
+                        <version>${mtf.tools.version}</version>
                         <classifier>mule-plugin</classifier>
                     </dependency>
                 </dependencies>

--- a/src/main/java/org/mule/extension/ftp/internal/connection/FtpConnectionProvider.java
+++ b/src/main/java/org/mule/extension/ftp/internal/connection/FtpConnectionProvider.java
@@ -181,7 +181,7 @@ public class FtpConnectionProvider extends FileSystemProvider<FtpFileSystem> imp
       client.setConnectTimeout(new Long(getConnectionTimeoutUnit().toMillis(getConnectionTimeout())).intValue());
     }
     if (getResponseTimeout() != null && getResponseTimeoutUnit() != null) {
-      client.setDefaultTimeout(new Long(getResponseTimeoutUnit().toMillis(getResponseTimeout())).intValue());
+      client.setDefaultTimeout((int)(getResponseTimeoutUnit().toMillis(getResponseTimeout())));
     }
 
     if (LOGGER.isDebugEnabled()) {

--- a/src/main/java/org/mule/extension/ftp/internal/connection/FtpConnectionProvider.java
+++ b/src/main/java/org/mule/extension/ftp/internal/connection/FtpConnectionProvider.java
@@ -181,7 +181,7 @@ public class FtpConnectionProvider extends FileSystemProvider<FtpFileSystem> imp
       client.setConnectTimeout(new Long(getConnectionTimeoutUnit().toMillis(getConnectionTimeout())).intValue());
     }
     if (getResponseTimeout() != null && getResponseTimeoutUnit() != null) {
-      client.setDefaultTimeout((int)(getResponseTimeoutUnit().toMillis(getResponseTimeout())));
+      client.setDefaultTimeout((int) (getResponseTimeoutUnit().toMillis(getResponseTimeout())));
     }
 
     if (LOGGER.isDebugEnabled()) {

--- a/src/main/java/org/mule/extension/ftp/internal/connection/FtpConnectionProvider.java
+++ b/src/main/java/org/mule/extension/ftp/internal/connection/FtpConnectionProvider.java
@@ -180,6 +180,9 @@ public class FtpConnectionProvider extends FileSystemProvider<FtpFileSystem> imp
     if (getConnectionTimeout() != null && getConnectionTimeoutUnit() != null) {
       client.setConnectTimeout(new Long(getConnectionTimeoutUnit().toMillis(getConnectionTimeout())).intValue());
     }
+    if (getResponseTimeout() != null && getResponseTimeoutUnit() != null) {
+      client.setDefaultTimeout(new Long(getResponseTimeoutUnit().toMillis(getResponseTimeout())).intValue());
+    }
 
     if (LOGGER.isDebugEnabled()) {
       LOGGER.debug(format("Connecting to host: '%s' at port: '%d'", connectionSettings.getHost(), connectionSettings.getPort()));

--- a/src/test/munit/configurations.xml
+++ b/src/test/munit/configurations.xml
@@ -17,6 +17,11 @@
         </ftp:connection>
     </ftp:config>
 
+    <ftp:config name="config-response-timeout">
+        <ftp:connection username="anonymous" password="password" host="localhost" port="${ftp.server.port}" workingDir="/" responseTimeoutUnit="MILLISECONDS" responseTimeout="1">
+        </ftp:connection>
+    </ftp:config>
+
     <ftp:config name="config-invalid-folder">
         <ftp:connection username="anonymous" password="password" host="localhost" port="${ftp.server.port}" workingDir="/invalid">
             <reconnection >

--- a/src/test/munit/configurations.xml
+++ b/src/test/munit/configurations.xml
@@ -17,8 +17,13 @@
         </ftp:connection>
     </ftp:config>
 
+    <ftp:config name="config-response-timeout-exception">
+        <ftp:connection username="timeout" password="timeout" host="localhost" port="${ftp.server.port}" workingDir="/" responseTimeoutUnit="MILLISECONDS" responseTimeout="1">
+        </ftp:connection>
+    </ftp:config>
+
     <ftp:config name="config-response-timeout">
-        <ftp:connection username="anonymous" password="password" host="localhost" port="${ftp.server.port}" workingDir="/" responseTimeoutUnit="MILLISECONDS" responseTimeout="1">
+        <ftp:connection username="timeout" password="timeout" host="localhost" port="${ftp.server.port}" workingDir="/" responseTimeoutUnit="SECONDS" responseTimeout="10">
         </ftp:connection>
     </ftp:config>
 

--- a/src/test/munit/ftp-directory-listener-post-processing-action-test-case.xml
+++ b/src/test/munit/ftp-directory-listener-post-processing-action-test-case.xml
@@ -147,7 +147,7 @@
     <flow name="renameToFlow">
         <ftp:listener config-ref="config" directory="." renameTo="renamed.bak" recursive="false">
             <scheduling-strategy>
-                <fixed-frequency />
+                <fixed-frequency frequency="200"/>
             </scheduling-strategy>
             <ftp:matcher filenamePattern="*.txt" />
         </ftp:listener>

--- a/src/test/munit/ftp-response-timeout-test-case.xml
+++ b/src/test/munit/ftp-response-timeout-test-case.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<mule xmlns:nav="http://www.mulesoft.org/schema/mule/nav"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xmlns:munit="http://www.mulesoft.org/schema/mule/munit"
+      xmlns:munit-tools="http://www.mulesoft.org/schema/mule/munit-tools"
+      xmlns="http://www.mulesoft.org/schema/mule/core"
+      xmlns:mtf="http://www.mulesoft.org/schema/mule/mtf"
+      xmlns:doc="http://www.mulesoft.org/schema/mule/documentation"
+      xmlns:java="http://www.mulesoft.org/schema/mule/java"
+
+      xsi:schemaLocation="
+		http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
+		http://www.mulesoft.org/schema/mule/mtf  http://www.mulesoft.org/schema/mule/mtf/current/mule-mtf.xsd
+		http://www.mulesoft.org/schema/mule/munit http://www.mulesoft.org/schema/mule/munit/current/mule-munit.xsd
+		http://www.mulesoft.org/schema/mule/java http://www.mulesoft.org/schema/mule/java/current/mule-java.xsd
+		http://www.mulesoft.org/schema/mule/munit-tools  http://www.mulesoft.org/schema/mule/munit-tools/current/mule-munit-tools.xsd
+		http://www.mulesoft.org/schema/mule/nav http://www.mulesoft.org/schema/mule/nav/current/mule-nav.xsd">
+    <munit:config name="ftp-response-timeout-test-case.xml" minMuleVersion="4.2.0"/>
+
+    <munit:dynamic-port propertyName="ftp.server.port"/>
+
+    <munit:before-suite name="startFtpTestServer-copyTestCase">
+        <java:invoke-static class="org.mule.extension.ftp.internal.lifecycle.FtpServerLifecycleManager"
+                            method="startFtpServer(String)">
+            <java:args>
+                #[{
+                arg0: ${ftp.server.port},
+                }]
+            </java:args>
+        </java:invoke-static>
+    </munit:before-suite>
+
+    <munit:after-suite name="clearFtpTestServer-copyTestCase">
+        <java:invoke-static class="org.mule.extension.ftp.internal.lifecycle.FtpServerLifecycleManager"
+                            method="stopFtpServer()">
+            <java:args>
+                #[{}]
+            </java:args>
+        </java:invoke-static>
+    </munit:after-suite>
+
+    <munit:test name="response-timeout-connectivity-test">
+        <munit:execution>
+            <try>
+                <mtf:test-connectivity config-ref="config-response-timeout"/>
+                <error-handler>
+                    <on-error-continue enableNotifications="false" logException="false" type="FTP:CONNECTION_TIMEOUT">
+                        <set-payload value="#[error]"/>
+                    </on-error-continue>
+                </error-handler>
+            </try>
+        </munit:execution>
+        <munit:validation>
+            <munit-tools:assert-equals actual="#[Java::isCausedBy(payload.cause, 'java.net.SocketTimeoutException')]"
+                                       expected="#[true]"/>
+        </munit:validation>
+    </munit:test>
+</mule>

--- a/src/test/munit/ftp-response-timeout-test-case.xml
+++ b/src/test/munit/ftp-response-timeout-test-case.xml
@@ -20,7 +20,7 @@
 
     <munit:dynamic-port propertyName="ftp.server.port"/>
 
-    <munit:before-suite name="startFtpTestServer-copyTestCase">
+    <munit:before-suite name="startFtpTestServer-response-timeout-test-case">
         <java:invoke-static class="org.mule.extension.ftp.internal.lifecycle.FtpServerLifecycleManager"
                             method="startFtpServer(String)">
             <java:args>
@@ -31,7 +31,7 @@
         </java:invoke-static>
     </munit:before-suite>
 
-    <munit:after-suite name="clearFtpTestServer-copyTestCase">
+    <munit:after-suite name="clearFtpTestServer-response-timeout-test-case">
         <java:invoke-static class="org.mule.extension.ftp.internal.lifecycle.FtpServerLifecycleManager"
                             method="stopFtpServer()">
             <java:args>

--- a/src/test/munit/ftp-response-timeout-test-case.xml
+++ b/src/test/munit/ftp-response-timeout-test-case.xml
@@ -40,10 +40,10 @@
         </java:invoke-static>
     </munit:after-suite>
 
-    <munit:test name="response-timeout-connectivity-test">
+    <munit:test name="response-timeout-connectivity-test" description="Should throw CONNECTION_TIMEOUT when response timeout is 1 milisecond">
         <munit:execution>
             <try>
-                <mtf:test-connectivity config-ref="config-response-timeout"/>
+                <mtf:test-connectivity config-ref="config-response-timeout-exception"/>
                 <error-handler>
                     <on-error-continue enableNotifications="false" logException="false" type="FTP:CONNECTION_TIMEOUT">
                         <set-payload value="#[error]"/>
@@ -55,5 +55,11 @@
             <munit-tools:assert-equals actual="#[Java::isCausedBy(payload.cause, 'java.net.SocketTimeoutException')]"
                                        expected="#[true]"/>
         </munit:validation>
+    </munit:test>
+
+    <munit:test name="response-timeout-connectivity-test-invalid-credentials" expectedErrorType="FTP:INVALID_CREDENTIALS" description="Should throw INVALID_LOGIN when response timeout is 30 seconds with invalid credentials">
+        <munit:execution>
+            <mtf:test-connectivity config-ref="config-response-timeout"/>
+        </munit:execution>
     </munit:test>
 </mule>


### PR DESCRIPTION
Added default timeout for FTPClient in order to avoid unlimited wait for socket read.
Unlimited wait for socket read may cause disposing issues.
This timeout do not affect long running operations (e.g. write operation).