### PR TITLE
W-11493458: added null check to FTPlist values

### DIFF
--- a/src/main/java/org/mule/extension/ftp/internal/command/FtpCommand.java
+++ b/src/main/java/org/mule/extension/ftp/internal/command/FtpCommand.java
@@ -326,7 +326,7 @@ public abstract class FtpCommand extends ExternalFileCommand<FtpFileSystem> {
         while (engine.hasNext()) {
           FTPFile[] files = engine.getNext(FTP_LIST_PAGE_SIZE);
           for (FTPFile file : files) {
-            if (FilenameUtils.getName(filePath).equals(file.getName())) {
+            if (file != null && FilenameUtils.getName(filePath).equals(file.getName())) {
               return Optional.ofNullable(file);
             }
           }


### PR DESCRIPTION
FTPListParseEngine.getNext() return an array of FTPFile. This array can contain null values and we are not validating this scenario. This is explained as a note in the [documentation](https://commons.apache.org/proper/commons-net/apidocs/org/apache/commons/net/ftp/FTPListParseEngine.html#getNext-int-) of the method.