### PR TITLE
W-14275959 : add getters and setters to POJO's 

### DIFF
--- a/src/main/java/org/mule/extension/ftp/api/FTPConnectionException.java
+++ b/src/main/java/org/mule/extension/ftp/api/FTPConnectionException.java
@@ -29,7 +29,4 @@ public class FTPConnectionException extends ConnectionException {
   public FTPConnectionException(String message, Throwable throwable, FileError fileError) {
     super(message, new ModuleException(fileError, throwable));
   }
-  public FTPConnectionException() {
-    super(); // Default constructor
-  }
 }

--- a/src/main/java/org/mule/extension/ftp/api/FTPConnectionException.java
+++ b/src/main/java/org/mule/extension/ftp/api/FTPConnectionException.java
@@ -29,4 +29,7 @@ public class FTPConnectionException extends ConnectionException {
   public FTPConnectionException(String message, Throwable throwable, FileError fileError) {
     super(message, new ModuleException(fileError, throwable));
   }
+  public FTPConnectionException() {
+    super(); // Default constructor
+  }
 }

--- a/src/main/java/org/mule/extension/ftp/api/FtpFileMatcher.java
+++ b/src/main/java/org/mule/extension/ftp/api/FtpFileMatcher.java
@@ -42,7 +42,7 @@ public class FtpFileMatcher extends FileMatcher<FtpFileMatcher, FtpFileAttribute
   private AtomicBoolean alreadyLoggedWarning = new AtomicBoolean();
 
   public FtpFileMatcher() {
-    this.timeUnit =TimeUnit.SECONDS;
+    this.timeUnit = TimeUnit.SECONDS;
     this.caseSensitive = true;
   }
 
@@ -250,6 +250,5 @@ public class FtpFileMatcher extends FileMatcher<FtpFileMatcher, FtpFileAttribute
 
 
 }
-
 
 

--- a/src/main/java/org/mule/extension/ftp/api/FtpFileMatcher.java
+++ b/src/main/java/org/mule/extension/ftp/api/FtpFileMatcher.java
@@ -41,6 +41,10 @@ public class FtpFileMatcher extends FileMatcher<FtpFileMatcher, FtpFileAttribute
   private static final Logger LOGGER = getLogger(FtpFileMatcher.class);
   private AtomicBoolean alreadyLoggedWarning = new AtomicBoolean();
 
+  public FtpFileMatcher() {
+    this.timeUnit =TimeUnit.SECONDS;
+    this.caseSensitive = true;
+  }
 
   /**
    * Files created before this date are rejected.
@@ -186,23 +190,62 @@ public class FtpFileMatcher extends FileMatcher<FtpFileMatcher, FtpFileAttribute
     return timestampSince;
   }
 
+  public void setTimestampSince(LocalDateTime timestampSince) {
+    this.timestampSince = timestampSince;
+  }
+
+
   public LocalDateTime getTimestampUntil() {
     return timestampUntil;
+  }
+
+  public void setTimestampUntil(LocalDateTime timestampUntil) {
+    this.timestampUntil = timestampUntil;
   }
 
   public TimeUnit getTimeUnit() {
     return timeUnit;
   }
 
+  public void setTimeUnit(TimeUnit timeUnit) {
+    this.timeUnit = timeUnit;
+  }
+
   public Long getUpdatedInTheLast() {
     return updatedInTheLast;
+  }
+
+  public void setUpdatedInTheLast(Long updatedInTheLast) {
+    this.updatedInTheLast = updatedInTheLast;
   }
 
   public Long getNotUpdatedInTheLast() {
     return notUpdatedInTheLast;
   }
 
+  public void setNotUpdatedInTheLast(Long notUpdatedInTheLast) {
+    this.notUpdatedInTheLast = notUpdatedInTheLast;
+  }
+
   public boolean isCaseSensitive() {
     return caseSensitive;
   }
+
+  public void setCaseSensitive(boolean caseSensitive) {
+    this.caseSensitive = caseSensitive;
+  }
+
+
+  public AtomicBoolean getAlreadyLoggedWarning() {
+    return alreadyLoggedWarning;
+  }
+
+  public void setAlreadyLoggedWarning(AtomicBoolean alreadyLoggedWarning) {
+    this.alreadyLoggedWarning = alreadyLoggedWarning;
+  }
+
+
 }
+
+
+

--- a/src/main/java/org/mule/extension/ftp/api/FtpFileMatcher.java
+++ b/src/main/java/org/mule/extension/ftp/api/FtpFileMatcher.java
@@ -231,6 +231,10 @@ public class FtpFileMatcher extends FileMatcher<FtpFileMatcher, FtpFileAttribute
     return caseSensitive;
   }
 
+  public boolean getCaseSensitive() {
+    return caseSensitive;
+  }
+
   public void setCaseSensitive(boolean caseSensitive) {
     this.caseSensitive = caseSensitive;
   }

--- a/src/main/java/org/mule/extension/ftp/api/FtpFileMatcher.java
+++ b/src/main/java/org/mule/extension/ftp/api/FtpFileMatcher.java
@@ -190,7 +190,7 @@ public class FtpFileMatcher extends FileMatcher<FtpFileMatcher, FtpFileAttribute
     return timestampSince;
   }
 
-  public void setTimestampSince(LocalDateTime timestampSince) {
+  public void setTimestampsince(LocalDateTime timestampSince) {
     this.timestampSince = timestampSince;
   }
 
@@ -199,7 +199,7 @@ public class FtpFileMatcher extends FileMatcher<FtpFileMatcher, FtpFileAttribute
     return timestampUntil;
   }
 
-  public void setTimestampUntil(LocalDateTime timestampUntil) {
+  public void setTimestampuntil(LocalDateTime timestampUntil) {
     this.timestampUntil = timestampUntil;
   }
 
@@ -207,7 +207,7 @@ public class FtpFileMatcher extends FileMatcher<FtpFileMatcher, FtpFileAttribute
     return timeUnit;
   }
 
-  public void setTimeUnit(TimeUnit timeUnit) {
+  public void setTimeunit(TimeUnit timeUnit) {
     this.timeUnit = timeUnit;
   }
 
@@ -215,7 +215,7 @@ public class FtpFileMatcher extends FileMatcher<FtpFileMatcher, FtpFileAttribute
     return updatedInTheLast;
   }
 
-  public void setUpdatedInTheLast(Long updatedInTheLast) {
+  public void setUpdatedInThelast(Long updatedInTheLast) {
     this.updatedInTheLast = updatedInTheLast;
   }
 
@@ -223,7 +223,7 @@ public class FtpFileMatcher extends FileMatcher<FtpFileMatcher, FtpFileAttribute
     return notUpdatedInTheLast;
   }
 
-  public void setNotUpdatedInTheLast(Long notUpdatedInTheLast) {
+  public void setNotUpdatedInThelast(Long notUpdatedInTheLast) {
     this.notUpdatedInTheLast = notUpdatedInTheLast;
   }
 
@@ -231,11 +231,11 @@ public class FtpFileMatcher extends FileMatcher<FtpFileMatcher, FtpFileAttribute
     return caseSensitive;
   }
 
-  public boolean getCaseSensitive() {
+  public boolean getFtpFileMatcherCaseSensitive() {
     return caseSensitive;
   }
 
-  public void setCaseSensitive(boolean caseSensitive) {
+  public void setFtpFileMatcherCaseSensitive(boolean caseSensitive) {
     this.caseSensitive = caseSensitive;
   }
 

--- a/src/main/java/org/mule/extension/ftp/api/ftp/FtpFileAttributes.java
+++ b/src/main/java/org/mule/extension/ftp/api/ftp/FtpFileAttributes.java
@@ -107,6 +107,10 @@ public class FtpFileAttributes extends AbstractFileAttributes {
     return regularFile;
   }
 
+  public boolean getRegularFile() {
+    return regularFile;
+  }
+
   public void setRegularFile(boolean regularFile) {
     this.regularFile = regularFile;
   }
@@ -119,6 +123,10 @@ public class FtpFileAttributes extends AbstractFileAttributes {
     return directory;
   }
 
+  public boolean getDirectory() {
+    return directory;
+  }
+
   public void setDirectory(boolean directory) {
     this.directory = directory;
   }
@@ -128,6 +136,10 @@ public class FtpFileAttributes extends AbstractFileAttributes {
    */
   @Override
   public boolean isSymbolicLink() {
+    return symbolicLink;
+  }
+
+  public boolean getSymbolicLink() {
     return symbolicLink;
   }
 

--- a/src/main/java/org/mule/extension/ftp/api/ftp/FtpFileAttributes.java
+++ b/src/main/java/org/mule/extension/ftp/api/ftp/FtpFileAttributes.java
@@ -97,6 +97,7 @@ public class FtpFileAttributes extends AbstractFileAttributes {
   public String getName() {
     return name;
   }
+
   public void setName(String name) {
     this.name = name;
   }

--- a/src/main/java/org/mule/extension/ftp/api/ftp/FtpFileAttributes.java
+++ b/src/main/java/org/mule/extension/ftp/api/ftp/FtpFileAttributes.java
@@ -61,11 +61,19 @@ public class FtpFileAttributes extends AbstractFileAttributes {
     symbolicLink = ftpFile.isSymbolicLink();
   }
 
+  // Adding default constructor
+  public FtpFileAttributes() {
+  }
+
   /**
    * @return The last time the file was modified, or {@code null} if such information is not available.
    */
   public LocalDateTime getTimestamp() {
     return timestamp;
+  }
+
+  public void setTimestamp(LocalDateTime timestamp) {
+    this.timestamp = timestamp;
   }
 
   /**
@@ -74,6 +82,9 @@ public class FtpFileAttributes extends AbstractFileAttributes {
   @Override
   public String getName() {
     return name;
+  }
+  public void setName(String name) {
+    this.name = name;
   }
 
   /**
@@ -84,12 +95,20 @@ public class FtpFileAttributes extends AbstractFileAttributes {
     return size;
   }
 
+  public void setSize(long size) {
+    this.size = size;
+  }
+
   /**
    * {@inheritDoc}
    */
   @Override
   public boolean isRegularFile() {
     return regularFile;
+  }
+
+  public void setRegularFile(boolean regularFile) {
+    this.regularFile = regularFile;
   }
 
   /**
@@ -100,6 +119,10 @@ public class FtpFileAttributes extends AbstractFileAttributes {
     return directory;
   }
 
+  public void setDirectory(boolean directory) {
+    this.directory = directory;
+  }
+
   /**
    * {@inheritDoc}
    */
@@ -108,11 +131,19 @@ public class FtpFileAttributes extends AbstractFileAttributes {
     return symbolicLink;
   }
 
+  public void setSymbolicLink(boolean symbolicLink) {
+    this.symbolicLink = symbolicLink;
+  }
+
   /**
    * {@inheritDoc}
    */
   @Override
   public String getPath() {
     return normalizePath(super.getPath());
+  }
+
+  public void setPath(String path) {
+    this.path = normalizePath(path);
   }
 }

--- a/src/main/java/org/mule/extension/ftp/api/ftp/FtpFileAttributes.java
+++ b/src/main/java/org/mule/extension/ftp/api/ftp/FtpFileAttributes.java
@@ -50,6 +50,9 @@ public class FtpFileAttributes extends AbstractFileAttributes {
    * @param uri the file's {@link URI}
    * @param ftpFile the {@link FTPFile} which represents the file on the FTP server
    */
+
+
+
   public FtpFileAttributes(URI uri, FTPFile ftpFile) {
     super(uri);
     timestamp = ftpFile.getTimestamp() != null ? asDateTime(ftpFile.getTimestamp().toInstant()) : null;
@@ -61,8 +64,19 @@ public class FtpFileAttributes extends AbstractFileAttributes {
     symbolicLink = ftpFile.isSymbolicLink();
   }
 
-  // Adding default constructor
+
   public FtpFileAttributes() {
+    super(createDefaultUri());
+    timestamp = null;
+    name = "";
+    size = 0;
+    regularFile = false;
+    directory = false;
+    symbolicLink = false;
+  }
+
+  private static URI createDefaultUri() {
+    return URI.create("file:///defaultPath");
   }
 
   /**
@@ -155,7 +169,4 @@ public class FtpFileAttributes extends AbstractFileAttributes {
     return normalizePath(super.getPath());
   }
 
-  public void setPath(String path) {
-    this.path = normalizePath(path);
-  }
 }


### PR DESCRIPTION
Default constructor (didn't add default constructor for enum in order to avoid overriding or interfering with the values already defined for the enum)
Getters for all properties 
Setters for all properties ( didn't add setters for constants)
